### PR TITLE
add type input

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref != 'refs/heads/main'
-    environment: staging
+    environment:
+      name: staging
+      url: https://staging.cinotify.cc/api/notify
     steps:
       - uses: actions/checkout@v4
       - name: Deploy
@@ -39,7 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
-    environment: production
+    environment:
+      name: production
+      url: https://www.cinotify.cc/api/notify
     steps:
       - uses: actions/checkout@v4
       - name: Deploy

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,6 +23,18 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm test
+  deploy_staging:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref != 'refs/heads/main'
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy
+        run: npx wrangler deploy -e staging
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
   deploy:
     runs-on: ubuntu-latest
     needs: test

--- a/src/mail.js
+++ b/src/mail.js
@@ -1,9 +1,9 @@
-export const payload = ({ subject, to, body, attachments }) => ({
+export const payload = ({ subject, to, type, body, attachments }) => ({
   // https://docs.sendgrid.com/api-reference/mail-send/mail-send#body
   attachments,
   content: [
     {
-      type: 'text/plain',
+      type: type ?? 'text/plain',
       value: body ?? ' ',
     },
   ],

--- a/src/mail.test.js
+++ b/src/mail.test.js
@@ -49,11 +49,11 @@ describe('mail', () => {
 
 describe('payload', () => {
   it('supports a type', () => {
-    input.type = 'text/html'
-    expect(payload(input).content[0].type).toBe('text/html')
-    input.type = 'text/plain'
-    expect(payload(input).content[0].type).toBe('text/plain')
-  })
+    input.type = 'text/html';
+    expect(payload(input).content[0].type).toBe('text/html');
+    input.type = 'text/plain';
+    expect(payload(input).content[0].type).toBe('text/plain');
+  });
   it('supports multiple recipients', () => {
     expect(
       payload({ to: 'one@example.com,two@example.com' }).personalizations[0].to,

--- a/src/mail.test.js
+++ b/src/mail.test.js
@@ -7,7 +7,7 @@ const fixture = {
   attachments: input.attachments,
   content: [
     {
-      type: 'text/plain',
+      type: 'text/html',
       value: input.body,
     },
   ],
@@ -48,6 +48,12 @@ describe('mail', () => {
 });
 
 describe('payload', () => {
+  it('supports a type', () => {
+    input.type = 'text/html'
+    expect(payload(input).content[0].type).toBe('text/html')
+    input.type = 'text/plain'
+    expect(payload(input).content[0].type).toBe('text/plain')
+  })
   it('supports multiple recipients', () => {
     expect(
       payload({ to: 'one@example.com,two@example.com' }).personalizations[0].to,

--- a/src/test.js
+++ b/src/test.js
@@ -9,7 +9,7 @@ export const input = {
   body: '<h1>an html body</h1>',
   subject: 'hello',
   to: 'ex@mple.com',
-  type: 'text/html'
+  type: 'text/html',
 };
 
 export const inputUrlEncoded = `to=${input.to}&subject=${input.subject}&body=${input.body}&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt&type=text/html`;

--- a/src/test.js
+++ b/src/test.js
@@ -6,9 +6,10 @@ export const input = {
       filename: 'hello.txt',
     },
   ],
-  body: 'this is the body',
+  body: '<h1>an html body</h1>',
   subject: 'hello',
   to: 'ex@mple.com',
+  type: 'text/html'
 };
 
-export const inputUrlEncoded = `to=${input.to}&subject=${input.subject}&body=${input.body}&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt`;
+export const inputUrlEncoded = `to=${input.to}&subject=${input.subject}&body=${input.body}&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt&type=text/html`;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,3 +5,8 @@ compatibility_flags = ["nodejs_compat"]
 routes = [
     { pattern = "www.cinotify.cc/api/*", zone_id = "8b83258726802e1e77310bd3b08dfefa" }
 ]
+
+[env.staging]
+routes = [
+    { pattern = "staging.cinotify.cc/api/*", zone_id = "8b83258726802e1e77310bd3b08dfefa" }
+]


### PR DESCRIPTION
for sending html email see https://github.com/cinotify/github-action/issues/15

```
curl --request POST 'https://staging.cinotify.cc/api/notify' -d "to=jesse@jesse.sh&subject=email body&body=<em>hello</em>.&type=text/html&attachments[][type]=text/plain&attachments[][content]=aGVsbG8sIHdvcmxkIQ==&attachments[][filename]=hello.txt"
```